### PR TITLE
Fix code-relevant typo

### DIFF
--- a/Localizer.js
+++ b/Localizer.js
@@ -123,7 +123,7 @@ function innerTranslateTextNodes(parent, translatedMessage, subsContainer) {
     const textOnlyIterator = subsContainer.textOnlyChilds[Symbol.iterator]();
 
     // for first element, fake the first element as the next element
-    let previousElement = { nextSibling: parent.fistChild };
+    let previousElement = { nextSibling: parent.firstChild };
     for (const message of splitTranslatedMessage) {
         // if it is placeholder, replace it with HTML element
         if (message.startsWith(UNIQUE_REPLACEMENT_ID)) {


### PR DESCRIPTION
I have no idea what influence this typo has, but it is relevant for the implementation.

For whatever reason all parameter-replacements etc. have worked so far, however, that's why I'd like to have a second pair of eyes look over that.. kinda embarrassing... typo. :see_no_evil: 
I mean, it's quite obvious that [this may be what is meant here](https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild).

From how I understand it, this could have lead to problems, when the first HTML element would need to be replaced with [`data-opt-i18n-keep-children`](https://github.com/TinyWebEx/Localizer/blob/master/README.md#keeping-child-elements-in-HTML), but this is not tested here.

/cc @tdulcet